### PR TITLE
Implement Stacks & Queues (array based)

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -2,7 +2,7 @@ package ads
 
 import "testing"
 
-func logSatisfaction(t *testing.T, ds string, c Container) {
+func logContainerSatisfaction(t *testing.T, ds string, c Container) {
 	t.Helper()
 	t.Logf("%s satisfies Container interface: %v", ds, c)
 }
@@ -14,9 +14,9 @@ func TestContainer_Satisfaction(t *testing.T) {
 
 	// Dynamic array
 	c = NewArray()
-	logSatisfaction(t, "Array", c)
+	logContainerSatisfaction(t, "Array", c)
 
 	// Doubly Linked list
 	ll := NewList()
-	logSatisfaction(t, "Doubly Linked List", ll)
+	logContainerSatisfaction(t, "Doubly Linked List", ll)
 }

--- a/list_test.go
+++ b/list_test.go
@@ -232,7 +232,7 @@ func TestListIterable_Error(t *testing.T) {
 	l := NewList()
 	i := l.Iterator()
 	if _, err := i.Next(); err == nil {
-		t.Errorf("i.Next() returned non-nill error, want error")
+		t.Errorf("i.Next() returned non-nil error, want error")
 	}
 }
 

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,104 @@
+package ads
+
+import "fmt"
+
+// Queue interface
+type Queue interface {
+	// Front element of the queue.
+	Front() (interface{}, error)
+	// Back element of the queue.
+	Back() (interface{}, error)
+	// Size returns the number of elements stored in the queue.
+	Size() int
+	// Empty removes all elements from the queue.
+	Empty()
+	// Push a new element into the queue.
+	Push(interface{}) error
+	// Pop the top element of the queue.
+	Pop() (interface{}, error)
+}
+
+// ArrayBasedQueue is a Queue that uses a fixed-size slice as the underlying container.
+type ArrayBasedQueue struct {
+	data             []interface{}
+	head, tail, size int
+}
+
+// NewArrayBasedQueue returns a new Queue of fixed size.
+func NewArrayBasedQueue(size uint) Queue {
+	q := &ArrayBasedQueue{}
+	q.data = make([]interface{}, size+1)
+	q.head = 0
+	q.tail = 0
+	return q
+}
+
+func (q *ArrayBasedQueue) isEmpty() bool {
+	return q.head == q.tail
+}
+
+// movePointer one place to the right, if array limit is met cycles to the start of the array.
+func (q *ArrayBasedQueue) movePointer(p int) int {
+	return (p + 1) % len(q.data)
+}
+
+func (q *ArrayBasedQueue) isFull() bool {
+	return q.movePointer(q.tail) == q.head
+}
+
+// Front element of the queue.
+func (q *ArrayBasedQueue) Front() (interface{}, error) {
+	if q.isEmpty() {
+		return nil, fmt.Errorf("empty queue")
+	}
+	return q.data[q.movePointer(q.head)], nil
+}
+
+// Back element of the queue.
+func (q *ArrayBasedQueue) Back() (interface{}, error) {
+	if q.isEmpty() {
+		return nil, fmt.Errorf("empty queue")
+	}
+	return q.data[q.tail], nil
+}
+
+// Size returns the number of elements stored in the queue.
+func (q *ArrayBasedQueue) Size() int {
+	if q.isEmpty() {
+		return 0
+	}
+	if q.tail > q.head {
+		return q.tail - q.head
+	}
+	return len(q.data) - q.head + q.tail
+}
+
+// Empty removes all elements from the queue.
+func (q *ArrayBasedQueue) Empty() {
+	// Avoid memory leaks (free references for garbage collector)
+	for i := range q.data {
+		q.data[i] = nil
+	}
+	q.head = 0
+	q.tail = 0
+}
+
+// Push a new element into the queue.
+func (q *ArrayBasedQueue) Push(v interface{}) error {
+	if q.isFull() {
+		return fmt.Errorf("queue overflowed, exceeded queue size %d", len(q.data)-1)
+	}
+	q.tail = q.movePointer(q.tail)
+	q.data[q.tail] = v
+	return nil
+}
+
+// Pop the top element of the queue.
+func (q *ArrayBasedQueue) Pop() (interface{}, error) {
+	if q.isEmpty() {
+		return nil, fmt.Errorf("empty queue")
+	}
+	q.data[q.head] = nil
+	q.head = q.movePointer(q.head)
+	return q.data[q.head], nil
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,247 @@
+package ads
+
+import (
+	"fmt"
+	"testing"
+)
+
+func logQueueSatisfaction(t *testing.T, ds string, q Queue) {
+	t.Helper()
+	t.Logf("%s satisfies Queue interface: %v", ds, q)
+}
+
+// TestQueueInterfaceSatisfaction verifies (during compilation) that the
+// multiple queue implementations satisfy the Queue interface.
+func TestQueueInterfaceSatisfaction(t *testing.T) {
+	var q Queue
+
+	// Array-based
+	q = NewArrayBasedQueue(1)
+	logQueueSatisfaction(t, "ArrayBasedStack", q)
+}
+
+type queueOpType int
+
+const (
+	queuePush queueOpType = iota
+	queuePop
+	queueEmpty
+)
+
+type queueOp struct {
+	op       queueOpType
+	input    int
+	mustFail bool
+	want     int
+}
+
+type intErrorResult struct {
+	v        int
+	mustFail bool
+}
+
+func validateQueueError(t *testing.T, producer string, err error, mustFail bool) {
+	t.Helper()
+	if err != nil && !mustFail {
+		t.Fatalf("%s failed; %v", producer, err)
+	} else if err == nil && mustFail {
+		t.Fatalf("%s returned non-nil error, want error", producer)
+	}
+}
+
+// TestArrayBasedQueue_ThroughOps will perform a set of operations against a newly
+// created queue and check for read-only operations results after each one is executed.
+// It will also perform the read-only operations before executing the test case operations.
+func TestArrayBasedQueue_ThroughOps(t *testing.T) {
+	tests := []struct {
+		name      string
+		size      int
+		ops       []queueOp
+		wantFront []intErrorResult
+		wantBack  []intErrorResult
+		wantSize  []int
+	}{
+		{
+			name: "fill and flush",
+			size: 4,
+			ops: []queueOp{
+				{op: queuePush, input: 1},
+				{op: queuePush, input: 2},
+				{op: queuePush, input: 3},
+				{op: queuePush, input: 4},
+				{op: queuePop, want: 1},
+				{op: queuePop, want: 2},
+				{op: queuePop, want: 3},
+				{op: queuePop, want: 4},
+			},
+			wantFront: []intErrorResult{
+				{v: 1}, {v: 1}, {v: 1}, {v: 1},
+				{v: 2}, {v: 3}, {v: 4}, {mustFail: true},
+			},
+			wantBack: []intErrorResult{
+				{v: 1}, {v: 2}, {v: 3}, {v: 4},
+				{v: 4}, {v: 4}, {v: 4}, {mustFail: true},
+			},
+			wantSize: []int{1, 2, 3, 4, 3, 2, 1, 0},
+		},
+		{
+			name: "fill and empty",
+			size: 8,
+			ops: []queueOp{
+				{op: queuePush, input: 1},
+				{op: queuePush, input: 2},
+				{op: queuePush, input: 3},
+				{op: queuePush, input: 4},
+				{op: queuePush, input: 5},
+				{op: queuePush, input: 6},
+				{op: queuePush, input: 7},
+				{op: queuePush, input: 8},
+				{op: queueEmpty},
+			},
+			wantFront: []intErrorResult{
+				{v: 1}, {v: 1}, {v: 1}, {v: 1},
+				{v: 1}, {v: 1}, {v: 1}, {v: 1},
+				{mustFail: true},
+			},
+			wantBack: []intErrorResult{
+				{v: 1}, {v: 2}, {v: 3}, {v: 4},
+				{v: 5}, {v: 6}, {v: 7}, {v: 8},
+				{mustFail: true},
+			},
+			wantSize: []int{1, 2, 3, 4, 5, 6, 7, 8, 0},
+		},
+		{
+			name: "cycle through underlying array one by one",
+			size: 3,
+			ops: []queueOp{
+				{op: queuePush, input: 1}, {op: queuePop, want: 1},
+				{op: queuePush, input: 1}, {op: queuePop, want: 1},
+				{op: queuePush, input: 1}, {op: queuePop, want: 1},
+				{op: queuePush, input: 1}, {op: queuePop, want: 1},
+			},
+			wantFront: []intErrorResult{
+				{v: 1}, {mustFail: true},
+				{v: 1}, {mustFail: true},
+				{v: 1}, {mustFail: true},
+				{v: 1}, {mustFail: true},
+			},
+			wantBack: []intErrorResult{
+				{v: 1}, {mustFail: true},
+				{v: 1}, {mustFail: true},
+				{v: 1}, {mustFail: true},
+				{v: 1}, {mustFail: true},
+			},
+			wantSize: []int{
+				1, 0,
+				1, 0,
+				1, 0,
+				1, 0,
+			},
+		},
+		{
+			name: "queue overflow",
+			size: 3,
+			ops: []queueOp{
+				{op: queuePush, input: 1},
+				{op: queuePush, input: 2},
+				{op: queuePush, input: 3},
+				{op: queuePush, input: 4, mustFail: true},
+				{op: queuePop, want: 1},
+				{op: queuePop, want: 2},
+				{op: queuePop, want: 3},
+				{op: queuePop, mustFail: true},
+				{op: queuePush, input: 4},
+				{op: queuePush, input: 5},
+				{op: queuePush, input: 6},
+				{op: queuePush, input: 7, mustFail: true},
+				{op: queueEmpty},
+			},
+			wantFront: []intErrorResult{
+				{v: 1}, {v: 1}, {v: 1}, {v: 1},
+				{v: 2}, {v: 3}, {mustFail: true}, {mustFail: true},
+				{v: 4}, {v: 4}, {v: 4}, {v: 4},
+				{mustFail: true},
+			},
+			wantBack: []intErrorResult{
+				{v: 1}, {v: 2}, {v: 3}, {v: 3},
+				{v: 3}, {v: 3}, {mustFail: true}, {mustFail: true},
+				{v: 4}, {v: 5}, {v: 6}, {v: 6},
+				{mustFail: true},
+			},
+			wantSize: []int{
+				1, 2, 3, 3,
+				2, 1, 0, 0,
+				1, 2, 3, 3,
+				0,
+			},
+		},
+		{
+			name: "queue of size 0",
+			size: 0,
+			ops: []queueOp{
+				{op: queuePush, mustFail: true},
+				{op: queuePop, mustFail: true},
+				{op: queueEmpty},
+			},
+			wantFront: []intErrorResult{
+				{mustFail: true}, {mustFail: true}, {mustFail: true},
+			},
+			wantBack: []intErrorResult{
+				{mustFail: true}, {mustFail: true}, {mustFail: true},
+			},
+			wantSize: []int{0, 0, 0},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q := NewArrayBasedQueue(uint(test.size))
+
+			// Perform read-only operations once
+			if _, err := q.Front(); err == nil {
+				t.Errorf("Front() returned non-nill error on empty queue, want error")
+			}
+			if _, err := q.Back(); err == nil {
+				t.Errorf("Back() returned non-nill error on empty queue, want error")
+			}
+			if s := q.Size(); s != 0 {
+				t.Errorf("Size() = %d, want 0", s)
+			}
+
+			for i, op := range test.ops {
+				switch op.op {
+				case queuePush:
+					validateQueueError(
+						t, fmt.Sprintf("Push(%d)", op.input),
+						q.Push(op.input),
+						op.mustFail)
+				case queuePop:
+					popResult, popError := q.Pop()
+					validateQueueError(t, "Pop()", popError, op.mustFail)
+					if !op.mustFail && popResult.(int) != op.want {
+						t.Fatalf("Pop(): %d, want %d", popResult, op.want)
+					}
+				case queueEmpty:
+					q.Empty()
+				}
+
+				wantFront := test.wantFront[i]
+				frontGot, frontErr := q.Front()
+				validateQueueError(t, "Front()", frontErr, wantFront.mustFail)
+				if !wantFront.mustFail && frontGot.(int) != wantFront.v {
+					t.Errorf("Front(): %d, want %d", frontGot, wantFront.v)
+				}
+
+				wantBack := test.wantBack[i]
+				backGot, backErr := q.Back()
+				validateQueueError(t, "Back()", backErr, wantBack.mustFail)
+				if !wantBack.mustFail && backGot.(int) != wantBack.v {
+					t.Errorf("Back(): %d, want %d", backGot, wantBack.v)
+				}
+
+				if q.Size() != test.wantSize[i] {
+					t.Errorf("Size(): %d, want %d", q.Size(), test.wantSize[i])
+				}
+			}
+		})
+	}
+}

--- a/stack.go
+++ b/stack.go
@@ -16,8 +16,7 @@ type Stack interface {
 	Pop() (interface{}, error)
 }
 
-// ArrayBasedStack is a Stack that uses a fixed-size slice as the
-// underlying container.
+// ArrayBasedStack is a Stack that uses a fixed-size slice as the underlying container.
 type ArrayBasedStack struct {
 	data      []interface{}
 	top, size int

--- a/stack.go
+++ b/stack.go
@@ -64,6 +64,9 @@ func (s *ArrayBasedStack) Pop() (interface{}, error) {
 	if s.top < 0 {
 		return nil, fmt.Errorf("empty stack")
 	}
+	v := s.data[s.top]
+	// Avoid memory leaks (free references for garbage collector)
+	s.data[s.top] = nil
 	s.top--
-	return s.data[s.top+1], nil
+	return v, nil
 }

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,70 @@
+package ads
+
+import "fmt"
+
+// Stack interface
+type Stack interface {
+	// Top returns the element at the top of the stack.
+	Top() (interface{}, error)
+	// Size returns the number of elements stored in the stack.
+	Size() int
+	// Empty removes all elements from the stack.
+	Empty()
+	// Push a new element into the stack.
+	Push(interface{}) error
+	// Pop the top element of the stack.
+	Pop() (interface{}, error)
+}
+
+// ArrayBasedStack is a Stack that uses a fixed-size slice as the
+// underlying container.
+type ArrayBasedStack struct {
+	data      []interface{}
+	top, size int
+}
+
+// NewArrayBasedStack returns a new Stack of fixed size.
+func NewArrayBasedStack(size uint) Stack {
+	s := &ArrayBasedStack{}
+	s.data = make([]interface{}, size)
+	s.top = -1
+	s.size = int(size) - 1
+	return s
+}
+
+// Top returns the element at the top of the stack.
+func (s *ArrayBasedStack) Top() (interface{}, error) {
+	if s.top < 0 {
+		return nil, fmt.Errorf("empty stack")
+	}
+	return s.data[s.top], nil
+}
+
+// Size returns the number of elements stored in the stack.
+func (s *ArrayBasedStack) Size() int {
+	return s.top + 1
+}
+
+// Empty removes all elements from the stack.
+func (s *ArrayBasedStack) Empty() {
+	s.top = -1
+}
+
+// Push a new element into the stack.
+func (s *ArrayBasedStack) Push(v interface{}) error {
+	if s.top == s.size {
+		return fmt.Errorf("stack overflowed, exceeded stack size %d", s.size+1)
+	}
+	s.top++
+	s.data[s.top] = v
+	return nil
+}
+
+// Pop the top element of the stack.
+func (s *ArrayBasedStack) Pop() (interface{}, error) {
+	if s.top < 0 {
+		return nil, fmt.Errorf("empty stack")
+	}
+	s.top--
+	return s.data[s.top+1], nil
+}

--- a/stack_test.go
+++ b/stack_test.go
@@ -12,9 +12,9 @@ func logStackSatisfaction(t *testing.T, ds string, s Stack) {
 	t.Logf("%s satisfies Stack interface: %v", ds, s)
 }
 
-// TestInterfaceSatisfaction verifies (during compilation) that the
+// TestStackInterfaceSatisfaction verifies (during compilation) that the
 // multiple stack implementations satisfy the Stack interface.
-func TestInterfaceSatisfaction(t *testing.T) {
+func TestStackInterfaceSatisfaction(t *testing.T) {
 	var s Stack
 
 	// Array-based

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,0 +1,117 @@
+package ads
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func logStackSatisfaction(t *testing.T, ds string, s Stack) {
+	t.Helper()
+	t.Logf("%s satisfies Stack interface: %v", ds, s)
+}
+
+// TestInterfaceSatisfaction verifies (during compilation) that the
+// multiple stack implementations satisfy the Stack interface.
+func TestInterfaceSatisfaction(t *testing.T) {
+	var s Stack
+
+	// Array-based
+	s = NewArrayBasedStack(1)
+	logStackSatisfaction(t, "ArrayBasedStack", s)
+}
+
+// testElementaryMethods will use methods Push, Pop and Top to verify correct implementation.
+func testElementaryMethods(t *testing.T, s Stack, n int) {
+	t.Helper()
+	content, want, got := make([]int, n), make([]int, n), make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		content[i] = i
+		want[i] = n - i - 1
+	}
+	for _, x := range content {
+		if err := s.Push(x); err != nil {
+			t.Errorf("Push() produced unexpected error; %v", err)
+		}
+	}
+	for s.Size() > 0 {
+		x, err := s.Top()
+		if err != nil {
+			t.Errorf("Top() produced unexpected error; %v", err)
+		}
+		y, err := s.Pop()
+		if err != nil {
+			t.Errorf("Pop() produced unexpected error; %v", err)
+		}
+		if y != x {
+			t.Errorf("Pop():%d != Top():%d", y, x)
+		}
+		got = append(got, x.(int))
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Fill-Flush test failed, got diff %s", diff)
+	}
+}
+
+func testErrorsOnEmptyList(t *testing.T, s Stack) {
+	t.Helper()
+	if _, err := s.Top(); err == nil {
+		t.Error("Top() returned non-nil error, want error")
+	}
+	if err := s.Push(1); err == nil {
+		t.Error("Push() returned non-nil error, want error")
+	}
+	if _, err := s.Pop(); err == nil {
+		t.Error("Pop() returned non-nil error, want error")
+	}
+}
+
+func testEmptyProcedure(t *testing.T, s Stack, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := s.Push(i); err != nil {
+			t.Errorf("Push() produced unexpected error; %v", err)
+		}
+	}
+	if s.Size() != n {
+		t.Errorf("Failed building stack of size %d, got size %d", n, s.Size())
+	}
+	s.Empty()
+	if s.Size() != 0 {
+		t.Errorf("Size(): %d after calling Empty()", s.Size())
+	}
+	if _, err := s.Pop(); err == nil {
+		t.Error("Pop() returned non-nil error, want error")
+	}
+	if _, err := s.Top(); err == nil {
+		t.Error("Top() returned non-nil error, want error")
+	}
+}
+
+func TestArrayBasedStack_ElementaryOperations(t *testing.T) {
+	tests := []int{0, 1, 2, 3, 10, 100}
+	for _, n := range tests {
+		testName := fmt.Sprintf("size %d", n)
+		t.Run(testName, func(t *testing.T) {
+			s := NewArrayBasedStack(uint(n))
+			testElementaryMethods(t, s, n)
+		})
+	}
+}
+
+func TestArrayBasedStack_Errors(t *testing.T) {
+	s := NewArrayBasedStack(0)
+	testErrorsOnEmptyList(t, s)
+}
+
+func TestArrayBasedStack_Empty(t *testing.T) {
+	tests := []int{0, 1, 2, 3, 10, 100}
+	for _, n := range tests {
+		testName := fmt.Sprintf("size %d", n)
+		t.Run(testName, func(t *testing.T) {
+			s := NewArrayBasedStack(uint(n))
+			testEmptyProcedure(t, s, n)
+		})
+	}
+}


### PR DESCRIPTION
Introduces Stacks and Queues data structures backed by a fixed-size slice.

The following interfaces and APIs were added:

## Stack

**Interface**:
```go
type Stack interface {
	// Top returns the element at the top of the stack.
	Top() (interface{}, error)
	// Size returns the number of elements stored in the stack.
	Size() int
	// Empty removes all elements from the stack.
	Empty()
	// Push a new element into the stack.
	Push(interface{}) error
	// Pop the top element of the stack.
	Pop() (interface{}, error)
}
```

**Struct and struct's API**:
```go
type ArrayBasedStack struct {}

func NewArrayBasedStack(size uint) Stack

func (s *ArrayBasedStack) Top() (interface{}, error)
func (s *ArrayBasedStack) Size() int
func (s *ArrayBasedStack) Empty()
func (s *ArrayBasedStack) Push(v interface{}) error
func (s *ArrayBasedStack) Pop() (interface{}, error)
```

## Queue

**Interface**:

```go
type Queue interface {
	// Front element of the queue.
	Front() (interface{}, error)
	// Back element of the queue.
	Back() (interface{}, error)
	// Size returns the number of elements stored in the queue.
	Size() int
	// Empty removes all elements from the queue.
	Empty()
	// Push a new element into the queue.
	Push(interface{}) error
	// Pop the top element of the queue.
	Pop() (interface{}, error)
}
```

**Struct and struct's API**:
```go
type ArrayBasedQueue struct {}

func NewArrayBasedQueue(size uint) Queue

func (q *ArrayBasedQueue) Front() (interface{}, error) 
func (q *ArrayBasedQueue) Back() (interface{}, error)
func (q *ArrayBasedQueue) Size() int
func (q *ArrayBasedQueue) Empty()
func (q *ArrayBasedQueue) Push(v interface{}) error
func (q *ArrayBasedQueue) Pop() (interface{}, error)
```

Closes #12, Closes #11

Pending benchmarks: #15, #16
Pending testable examples: #17, #18