### PR TITLE
Implement Hash Tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Algorithms &amp; Data Structures implemented in Golang.
 * [**Linked Lists**](https://en.wikipedia.org/wiki/Linked_list) [(`list.go`)](list.go)
 * [**Stacks**](https://en.wikipedia.org/wiki/Stack_(abstract_data_type)) [(`stack.go`)](stack.go)
 * [**Queue**](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)) [(`queue.go`)](queue.go)
+* [**Hash Table**](https://en.wikipedia.org/wiki/Hash_table) [(`hash_table.go`)](hash_table.go)

--- a/hash_table.go
+++ b/hash_table.go
@@ -1,0 +1,144 @@
+package ads
+
+const (
+	// hashTableInitialSize is the initial table size.
+	hashTableInitialSize int = 8
+	// hashTableFMultiplier is the prime p used in the Polynomial Rolling Hash algorithm.
+	hashTableFMultiplier int = 53
+)
+
+// HashTable implementation using an Open Addressing strategy with Linear Probing.
+type HashTable struct {
+	data []*hashTableBucket
+	// capacity is the number of available buckets
+	capacity int
+	// length is the number of used buckets
+	length int
+}
+
+// hasTableBucket stores the key/value pair and a deleted flag.
+type hashTableBucket struct {
+	key     string
+	value   interface{}
+	deleted bool
+}
+
+// NewHashTable returns a newly initialized hash table.
+func NewHashTable() *HashTable {
+	return new(HashTable).init()
+}
+
+// init initializes hash table.
+func (h *HashTable) init() *HashTable {
+	h.data = make([]*hashTableBucket, hashTableInitialSize)
+	h.capacity = hashTableInitialSize
+	h.length = 0
+	return h
+}
+
+func (h *HashTable) initLazy() {
+	if h.data == nil || h.capacity == 0 {
+		h.init()
+	}
+}
+
+// hash returns the integer hash of a given string using Polynomial Rolling Hash algorithm.
+func (h *HashTable) hash(k string) int {
+	hash := 0
+	for _, c := range k {
+		hash = (hash*hashTableFMultiplier + int(c)) % h.capacity
+	}
+	return hash
+}
+
+// probe computes the linear probing sequence for a hashed number k at the i-th location.
+func (h *HashTable) probe(k, i int) int {
+	return (k + i) % h.capacity
+}
+
+// Get the value stored in the given key. Returns nil, false if it doesn't exit.
+func (h *HashTable) Get(k string) (interface{}, bool) {
+	h.initLazy()
+	hash := h.hash(k)
+	for i, j := 0, h.probe(hash, 0); h.data[j] != nil; i, j = i+1, h.probe(hash, i+1) {
+		if !h.data[j].deleted && h.data[j].key == k {
+			return h.data[j].value, true
+		}
+	}
+	return nil, false
+}
+
+// Set or update a value using given key.
+func (h *HashTable) Set(k string, v interface{}) {
+	h.initLazy()
+	// Maximum load is based in CPython's USABLE_FRACTION
+	// https://github.com/python/cpython/blob/master/Objects/dictobject.c#L412
+	if h.length >= (h.capacity<<1)/2 {
+		h.resize()
+	}
+	hash := h.hash(k)
+	deleted := -1
+	j := h.probe(hash, 0)
+	for i := 1; h.data[j] != nil; i++ {
+		if h.data[j].deleted && deleted == -1 {
+			deleted = j
+		}
+		if !h.data[j].deleted && h.data[j].key == k {
+			break
+		}
+		j = h.probe(hash, i)
+	}
+
+	switch {
+	case h.data[j] != nil: // Update k with v
+		h.data[j].value = v
+	case deleted != -1: // Found slot before NIL
+		h.data[deleted].key = k
+		h.data[deleted].value = v
+		h.data[deleted].deleted = false
+		h.length++
+	default: // Bucket is NIL
+		h.data[j] = &hashTableBucket{key: k, value: v, deleted: false}
+		h.length++
+	}
+}
+
+// resize re-allocates every (non-deleted) element in a new table.
+func (h *HashTable) resize() {
+	// New capacity is based in CPython's 3.4.0-3.6.0 GROWTH_RATE
+	// https://github.com/python/cpython/blob/master/Objects/dictobject.c#L427
+	h.capacity = (h.length * 2) + (h.capacity / 2)
+	h.length = 0
+	tmp := h.data
+	h.data = make([]*hashTableBucket, h.capacity)
+	for _, kv := range tmp {
+		if kv != nil && !kv.deleted {
+			h.Set(kv.key, kv.value)
+		}
+	}
+}
+
+// Remove the value stored at the given key
+func (h *HashTable) Remove(k string) {
+	h.initLazy()
+	hash := h.hash(k)
+	for i, j := 0, h.probe(hash, 0); h.data[j] != nil; i, j = i+1, h.probe(hash, i+1) {
+		if !h.data[j].deleted && h.data[j].key == k {
+			h.data[j].deleted = true
+			h.data[j].value = nil // free reference to removed value
+			h.length--
+			return
+		}
+	}
+}
+
+// Size returns the number of elements stored in the hash table.
+func (h *HashTable) Size() int {
+	return h.length
+}
+
+// Empty removes all elements from the hash table.
+func (h *HashTable) Empty() {
+	h.data = nil
+	h.init()
+}

--- a/hash_table_test.go
+++ b/hash_table_test.go
@@ -1,0 +1,290 @@
+package ads
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
+
+type hashTableOpType int
+
+const (
+	hashTableSet hashTableOpType = iota
+	hashTableGet
+	hashTableDelete
+	hashTableClear
+)
+
+type hashTableOp struct {
+	op    hashTableOpType
+	key   string
+	value int
+}
+
+func TestHashTable_ThroughOps(t *testing.T) {
+	tests := []struct {
+		name string
+		ops  []hashTableOp
+	}{
+		{
+			name: "fill before resize then query",
+			ops: []hashTableOp{
+				{op: hashTableSet, key: "a", value: 1},
+				{op: hashTableSet, key: "b", value: 2},
+				{op: hashTableSet, key: "c", value: 3},
+				{op: hashTableSet, key: "d", value: 4},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableGet, key: "b"},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableGet, key: "d"},
+			},
+		},
+		{
+			name: "fill and flush before resize then query",
+			ops: []hashTableOp{
+				{op: hashTableSet, key: "a", value: 1},
+				{op: hashTableSet, key: "b", value: 2},
+				{op: hashTableSet, key: "c", value: 3},
+				{op: hashTableSet, key: "d", value: 4},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableGet, key: "b"},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableGet, key: "d"},
+				{op: hashTableDelete, key: "a"},
+				{op: hashTableDelete, key: "b"},
+				{op: hashTableDelete, key: "c"},
+				{op: hashTableDelete, key: "c"},
+			},
+		},
+		{
+			name: "fill and resize then query and empty",
+			ops: []hashTableOp{
+				{op: hashTableSet, key: "a", value: 1},
+				{op: hashTableSet, key: "b", value: 2},
+				{op: hashTableSet, key: "c", value: 3},
+				{op: hashTableSet, key: "d", value: 4},
+				{op: hashTableSet, key: "e", value: 5},
+				{op: hashTableSet, key: "f", value: 6},
+				{op: hashTableSet, key: "g", value: 7},
+				{op: hashTableSet, key: "h", value: 8},
+				{op: hashTableSet, key: "i", value: 9},
+				{op: hashTableSet, key: "j", value: 10},
+				{op: hashTableSet, key: "k", value: 11},
+				{op: hashTableSet, key: "l", value: 12},
+				{op: hashTableSet, key: "m", value: 13},
+				{op: hashTableSet, key: "n", value: 14},
+				{op: hashTableSet, key: "o", value: 15},
+				{op: hashTableSet, key: "p", value: 16},
+				{op: hashTableSet, key: "q", value: 17},
+				{op: hashTableSet, key: "r", value: 18},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableGet, key: "b"},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableGet, key: "d"},
+				{op: hashTableGet, key: "e"},
+				{op: hashTableGet, key: "f"},
+				{op: hashTableGet, key: "g"},
+				{op: hashTableGet, key: "h"},
+				{op: hashTableGet, key: "i"},
+				{op: hashTableGet, key: "j"},
+				{op: hashTableGet, key: "k"},
+				{op: hashTableGet, key: "l"},
+				{op: hashTableGet, key: "m"},
+				{op: hashTableGet, key: "n"},
+				{op: hashTableGet, key: "o"},
+				{op: hashTableGet, key: "p"},
+				{op: hashTableGet, key: "q"},
+				{op: hashTableGet, key: "r"},
+				{op: hashTableClear},
+			},
+		},
+		{
+			name: "query invalid keys",
+			ops: []hashTableOp{
+				{op: hashTableSet, key: "a", value: 1},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableDelete, key: "a"},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableSet, key: "b", value: 2},
+				{op: hashTableGet, key: "b"},
+				{op: hashTableDelete, key: "b"},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableSet, key: "c", value: 3},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableDelete, key: "c"},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableSet, key: "d", value: 4},
+				{op: hashTableGet, key: "d"},
+				{op: hashTableDelete, key: "d"},
+				{op: hashTableGet, key: "d"},
+			},
+		},
+		{
+			name: "reuse deleted buckets",
+			ops: []hashTableOp{
+				{op: hashTableSet, key: "a", value: 1},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableDelete, key: "a"},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableSet, key: "a", value: 1},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableSet, key: "b", value: 2},
+				{op: hashTableGet, key: "b"},
+				{op: hashTableDelete, key: "b"},
+				{op: hashTableSet, key: "b", value: 2},
+				{op: hashTableGet, key: "b"},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableSet, key: "c", value: 3},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableDelete, key: "c"},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableSet, key: "c", value: 3},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableSet, key: "d", value: 4},
+				{op: hashTableGet, key: "d"},
+				{op: hashTableDelete, key: "d"},
+				{op: hashTableGet, key: "d"},
+				{op: hashTableSet, key: "d", value: 4},
+				{op: hashTableGet, key: "d"},
+			},
+		},
+		{
+			name: "update values",
+			ops: []hashTableOp{
+				{op: hashTableSet, key: "a", value: 1},
+				{op: hashTableGet, key: "a"},
+				{op: hashTableSet, key: "a", value: 2},
+				{op: hashTableSet, key: "b", value: 2},
+				{op: hashTableGet, key: "b"},
+				{op: hashTableSet, key: "b", value: 3},
+				{op: hashTableSet, key: "c", value: 3},
+				{op: hashTableGet, key: "c"},
+				{op: hashTableSet, key: "c", value: 4},
+				{op: hashTableSet, key: "d", value: 4},
+				{op: hashTableGet, key: "d"},
+				{op: hashTableSet, key: "d", value: 5},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			table := NewHashTable()
+			control := make(map[string]int)
+
+			for _, op := range test.ops {
+				switch op.op {
+				case hashTableSet:
+					table.Set(op.key, op.value)
+					control[op.key] = op.value
+				case hashTableGet:
+					tv, tok := table.Get(op.key)
+					cv, cok := control[op.key]
+					if (cok && tv.(int) != cv) || tok != cok {
+						t.Fatalf("table.Get(%s): %d, %v want %d, %v", op.key, tv.(int), tok, cv, cok)
+					}
+				case hashTableDelete:
+					table.Remove(op.key)
+					delete(control, op.key)
+				case hashTableClear:
+					control = make(map[string]int)
+					table.Empty()
+				}
+				if len(control) != table.Size() {
+					t.Fatalf("table.Size(): %d, want %d", table.Size(), len(control))
+				}
+			}
+		})
+	}
+}
+
+func TestHashTable_LargeDataSets(t *testing.T) {
+	tests := []int{
+		4,
+		5,
+		50,
+		100,
+		1000,
+		10000,
+		100000,
+	}
+
+	genKey := func(n int) string {
+		b := make([]byte, n)
+		rand.Read(b)
+		return fmt.Sprintf("%x", b)
+	}
+
+	for _, n := range tests {
+		t.Run(fmt.Sprintf("n = %d", n), func(t *testing.T) {
+			table := &HashTable{}
+			control := make(map[string]int)
+
+			// 1. Load n keys and query them
+			for i := 1; i <= n; i++ {
+				key := genKey(20)
+				table.Set(key, i)
+				control[key] = i
+				tv, tok := table.Get(key)
+				cv, cok := control[key]
+				if tv != cv || !tok || !cok {
+					t.Fatalf("table.Get(%s): %d, %v want %d, %v", key, tv.(int), tok, cv, cok)
+				}
+				if len(control) != table.Size() {
+					t.Fatalf("table.Size(): %d, want %d", table.Size(), len(control))
+				}
+			}
+			// 2. Update n keys and query
+			for k, v := range control {
+				table.Set(k, -1*v)
+				control[k] = -1 * v
+				tv, tok := table.Get(k)
+				cv, cok := control[k]
+				if tv != cv || !tok || !cok {
+					t.Fatalf("table.Get(%s): %d, %v want %d, %v", k, tv.(int), tok, cv, cok)
+				}
+				if len(control) != table.Size() {
+					t.Fatalf("table.Size(): %d, want %d", table.Size(), len(control))
+				}
+			}
+			// 3. Query n / 3 random keys
+			for i := 0; i < n/3; i++ {
+				key := genKey(20)
+				tv, tok := table.Get(key)
+				cv, cok := control[key]
+				if tok != cok || (cok && tv.(int) != cv) {
+					t.Fatalf("table.Get(%s): %d, %v want %d, %v", key, tv.(int), tok, cv, cok)
+				}
+			}
+			// 4. Delete n / 3 random keys
+			count := 0
+			for k := range control {
+				if count > n/3 {
+					break
+				}
+				table.Remove(k)
+				delete(control, k)
+				if len(control) != table.Size() {
+					t.Fatalf("table.Size(): %d, want %d", table.Size(), len(control))
+				}
+			}
+			// 5. Query all keys
+			for k := range control {
+				tv, tok := table.Get(k)
+				cv, cok := control[k]
+				if tv != cv || !tok || !cok {
+					t.Fatalf("table.Get(%s): %d, %v want %d, %v", k, tv.(int), tok, cv, cok)
+				}
+				if len(control) != table.Size() {
+					t.Fatalf("table.Size(): %d, want %d", table.Size(), len(control))
+				}
+			}
+			// 6. Flush table
+			control = make(map[string]int)
+			table.Empty()
+			if len(control) != table.Size() {
+				t.Fatalf("table.Size(): %d, want %d", table.Size(), len(control))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduces the Hash Table data structure using [**open addressing**](https://en.wikipedia.org/wiki/Hash_table#Open_addressing) and [**linear probing**](https://en.wikipedia.org/wiki/Linear_probing). 

* The mapping is from `string` to `interface{}`.
* String keys are mapped to integers using **[Polynomial Rolling Hash](https://en.wikipedia.org/wiki/Rolling_hash)**.
* Max load (sometimes called *alpha*), and growth rate values are inspired in **[CPython's dict implementation](https://github.com/python/cpython/blob/master/Objects/dictobject.c)**.

The API exposed by this change is:

```go
type HashTable struct {}

func NewHashTable() *HashTable

func (h *HashTable) Get(k string) (interface{}, bool)
func (h *HashTable) Set(k string, v interface{})
func (h *HashTable) Remove(k string)
func (h *HashTable) Size() int
func (h *HashTable) Empty()
```

### Future improvements

Add resize down strategy. Right now, resizing when `used == load(previous size) /2` can be the triggering value.

### Notes

Closes #20 
Pending benchmarks #21 
Pending testable examples #22 