### PR TITLE
Implements Fenwick Trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Algorithms &amp; Data Structures implemented in Golang.
 * [**Stacks**](https://en.wikipedia.org/wiki/Stack_(abstract_data_type)) [(`stack.go`)](stack.go)
 * [**Queue**](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)) [(`queue.go`)](queue.go)
 * [**Hash Table**](https://en.wikipedia.org/wiki/Hash_table) [(`hash_table.go`)](hash_table.go)
+* [**Fenwick Tree**](https://en.wikipedia.org/wiki/Fenwick_tree) [(`fenwick_tree.go`)](fenwick_tree.go)

--- a/fenwick_tree.go
+++ b/fenwick_tree.go
@@ -16,7 +16,7 @@ func NewFenwickTree(size int) *FenwickTree {
 
 // Get returns the prefix sum of the first i elements.
 func (t *FenwickTree) Get(i int) (int, error) {
-	if i > t.n {
+	if i <= 0 || i > t.n {
 		return 0, fmt.Errorf("tree size is %d, got query for %d elements", t.n, i)
 	}
 	s := 0

--- a/fenwick_tree.go
+++ b/fenwick_tree.go
@@ -32,9 +32,7 @@ func (t *FenwickTree) Add(i, value int) error {
 	if i <= 0 || i > t.n {
 		return fmt.Errorf("invalid index %d", i)
 	}
-	fmt.Printf("Adding %d at index %d\n", value, i)
 	for i <= t.n {
-		fmt.Printf("\tindex %d\n", i)
 		t.bit[i] += value
 		i += i & (-i)
 	}

--- a/fenwick_tree.go
+++ b/fenwick_tree.go
@@ -1,0 +1,42 @@
+package ads
+
+import "fmt"
+
+// FenwickTree is a binary indexed tree with optimal complexity for computing prefix sums.
+// Important: this implementation is one-indexed.
+type FenwickTree struct {
+	bit []int
+	n   int
+}
+
+// NewFenwickTree returns a zero-initialized Fenwick Tree.
+func NewFenwickTree(size int) *FenwickTree {
+	return &FenwickTree{n: size, bit: make([]int, size+1)}
+}
+
+// Get returns the prefix sum of the first i elements.
+func (t *FenwickTree) Get(i int) (int, error) {
+	if i > t.n {
+		return 0, fmt.Errorf("tree size is %d, got query for %d elements", t.n, i)
+	}
+	s := 0
+	for i > 0 {
+		s += t.bit[i]
+		i -= i & (-i)
+	}
+	return s, nil
+}
+
+// Add value at the given index.
+func (t *FenwickTree) Add(i, value int) error {
+	if i <= 0 || i > t.n {
+		return fmt.Errorf("invalid index %d", i)
+	}
+	fmt.Printf("Adding %d at index %d\n", value, i)
+	for i <= t.n {
+		fmt.Printf("\tindex %d\n", i)
+		t.bit[i] += value
+		i += i & (-i)
+	}
+	return nil
+}

--- a/fenwick_tree_test.go
+++ b/fenwick_tree_test.go
@@ -1,0 +1,63 @@
+package ads
+
+import "testing"
+
+type fwtOpType uint
+
+const (
+	fwtOpAdd fwtOpType = iota
+	fwtOpGet
+)
+
+type fwtOp struct {
+	op    fwtOpType
+	value int
+	index int
+	want  int
+}
+
+func TestFenwickTree(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		ops  []fwtOp
+	}{
+		{
+			name: "basic",
+			size: 5,
+			ops: []fwtOp{
+				{op: fwtOpAdd, value: 1, index: 1},
+				{op: fwtOpAdd, value: 2, index: 2},
+				{op: fwtOpAdd, value: 3, index: 3},
+				{op: fwtOpAdd, value: 4, index: 4},
+				{op: fwtOpAdd, value: 5, index: 5},
+				{op: fwtOpGet, index: 1, want: 1},
+				{op: fwtOpGet, index: 2, want: 3},
+				{op: fwtOpGet, index: 3, want: 6},
+				{op: fwtOpGet, index: 4, want: 10},
+				{op: fwtOpGet, index: 5, want: 15},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fwt := NewFenwickTree(test.size)
+			for _, op := range test.ops {
+				switch op.op {
+				case fwtOpAdd:
+					if err := fwt.Add(op.index, op.value); err != nil {
+						t.Fatalf("Add(%d, %d) returned unexpected error; %v", op.index, op.value, err)
+					}
+				case fwtOpGet:
+					got, err := fwt.Get(op.index)
+					if err != nil {
+						t.Fatalf("Get(%d) returned unexpected error; %v", op.index, err)
+					}
+					if op.want != got {
+						t.Errorf("Get(%d): %d, want %d", op.index, got, op.want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/fenwick_tree_test.go
+++ b/fenwick_tree_test.go
@@ -1,6 +1,8 @@
 package ads
 
-import "testing"
+import (
+	"testing"
+)
 
 type fwtOpType uint
 
@@ -38,6 +40,34 @@ func TestFenwickTree(t *testing.T) {
 				{op: fwtOpGet, index: 5, want: 15},
 			},
 		},
+		{
+			name: "updates and queries",
+			size: 10,
+			ops: []fwtOp{
+				{op: fwtOpAdd, value: 234, index: 1},
+				{op: fwtOpAdd, value: 6, index: 2},
+				{op: fwtOpAdd, value: 1, index: 3},
+				{op: fwtOpAdd, value: -61, index: 4},
+				{op: fwtOpAdd, value: 78, index: 5},
+				{op: fwtOpAdd, value: 69, index: 6},
+				{op: fwtOpAdd, value: 72, index: 7},
+				{op: fwtOpAdd, value: 11, index: 8},
+				{op: fwtOpAdd, value: -21, index: 9},
+				{op: fwtOpAdd, value: 25, index: 10},
+				{op: fwtOpGet, index: 9, want: 389},
+				{op: fwtOpAdd, value: 90, index: 10},
+				{op: fwtOpAdd, value: -32, index: 8},
+				{op: fwtOpGet, index: 2, want: 240},
+				{op: fwtOpGet, index: 5, want: 258},
+				{op: fwtOpGet, index: 8, want: 378},
+				{op: fwtOpGet, index: 10, want: 472},
+				{op: fwtOpAdd, value: -472, index: 1},
+				{op: fwtOpGet, index: 10, want: 0},
+				{op: fwtOpGet, index: 6, want: -145},
+				{op: fwtOpAdd, value: 145, index: 5},
+				{op: fwtOpGet, index: 6, want: 0},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -55,6 +85,48 @@ func TestFenwickTree(t *testing.T) {
 					}
 					if op.want != got {
 						t.Errorf("Get(%d): %d, want %d", op.index, got, op.want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFenwickTree_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+		ops  []fwtOp
+	}{
+		{
+			name: "operating on empty tree",
+			size: 0,
+			ops: []fwtOp{
+				{op: fwtOpGet, index: 1},
+				{op: fwtOpAdd, index: 1, value: 1},
+			},
+		},
+		{
+			name: "invalid indexes",
+			size: 10,
+			ops: []fwtOp{
+				{op: fwtOpGet, index: 0}, {op: fwtOpGet, index: 11},
+				{op: fwtOpAdd, index: 0}, {op: fwtOpAdd, index: 11},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fwt := NewFenwickTree(test.size)
+			for _, op := range test.ops {
+				switch op.op {
+				case fwtOpAdd:
+					if err := fwt.Add(op.index, op.value); err == nil {
+						t.Errorf("Add(%d, %d) returned non-nil error, want error", op.index, op.value)
+					}
+				case fwtOpGet:
+					if _, err := fwt.Get(op.index); err == nil {
+						t.Errorf("Get(%d) returned non-nil error, want error", op.index)
 					}
 				}
 			}


### PR DESCRIPTION
Introduced the Fenwick Tree data structure.

This change introduces the following new API:

```go
type FenwickTree struct {}

func NewFenwickTree(size int) *FenwickTree

func (t *FenwickTree) Get(i int) (int, error)
func (t *FenwickTree) Add(i, value int) error 
```

### Future improvements

Add initialization from list of integers (#29), support range queries (#28) and expand to 2D version (#27).

### Notes
Closes #24 
Pending benchmarks #26 
Pending testable examples #25 